### PR TITLE
Prevent trending from overlapping on non home page waterfalls

### DIFF
--- a/components/css/go-trending.css
+++ b/components/css/go-trending.css
@@ -148,6 +148,15 @@
 		width: 300px;
 	}
 
+	.paged .widget-go-trending {
+		top: 730px;
+	}
+
+	.tax-channel .widget-go-trending,
+	.tax-channel.paged .widget-go-trending {
+		top: 778px;
+	}
+
 	.trending-post,
 	.trending-post .channel {
 		font-size: .8125rem;


### PR DESCRIPTION
See: https://github.com/GigaOM/gigaom/issues/6766

![screen shot 2015-02-23 at 3 55 33 pm](https://cloud.githubusercontent.com/assets/430385/6336958/6e65ffac-bb74-11e4-9694-7e0f76e65189.png)
