### PR TITLE
Baselining probably trending on gigaom winner

### DIFF
--- a/components/class-go-trending.php
+++ b/components/class-go-trending.php
@@ -185,14 +185,10 @@ class GO_Trending
 			$calc_d = $sum_x * $sum_x;
 
 			$trend = ( $calc_a - $calc_b ) / ( $calc_c - $calc_d );
-			if ( $trend < 0 )
-			{
-				$trend_direction = 'down';
-			}//end if
-			elseif ( $trend >= 0 && $trend <= 0.5 )
+			if ( $trend <= 0.5 )
 			{
 				$trend_direction = 'dash';
-			}//end elseif
+			}//end if
 			elseif ( $trend > 0.5 )
 			{
 				$trend_direction = 'up';
@@ -223,37 +219,6 @@ class GO_Trending
 
 				$post_data['sections'][ $key ][] = html_entity_decode( $value );
 			}//end foreach
-
-			// attempt to fetch the post
-			if ( function_exists( 'wpcom_vip_get_page_by_path' ) )
-			{
-				$post = wpcom_vip_get_page_by_path( $path, OBJECT, 'post' );
-			}//end if
-			else
-			{
-				$post = get_page_by_path( $path, OBJECT, 'post' );
-			}//end else
-
-			// if we can find a post by path and it has a thumbnail, use that instead
-			if ( $post && ! empty( $post->ID ) )
-			{
-				if ( has_post_thumbnail( $post->ID ) )
-				{
-					$thumbnail = get_the_post_thumbnail( $post->ID, 'small-square-thumbnail' );
-
-					preg_match( '!src="([^"]+)"!', $thumbnail, $matches );
-
-					$thumbnail = $matches[1];
-
-					// let's make sure old images are pointing at the correct location
-					$thumbnail = preg_replace( '!src="(https?)://pro\.!', 'src="$1://research.', $thumbnail );
-
-					// point at the correct uploads directory
-					$thumbnail = preg_replace( '!src="(https?)://research\.gigaom\.com/files/!', 'src="$1://research.gigaom.com/wp-content/uploads/', $thumbnail );
-
-					$post_data['thumbnail'] = $thumbnail;
-				}//end if
-			}//end if
 
 			$massaged_data[] = $post_data;
 			$rank++;

--- a/components/css/go-trending.css
+++ b/components/css/go-trending.css
@@ -81,10 +81,6 @@
 	padding: 0;
 }
 
-.trending-post .channel {
-	display: none;
-}
-
 .trending-post .trend a {
 	font-size: 2rem;
 }
@@ -135,8 +131,8 @@
 	display: block;
 }
 
-.widget-go-trending.show-channel .channel {
-	display: block;
+.widget-go-trending.hide-channel .channel {
+	display: none;
 }
 
 @media screen and (min-width: 960px) {

--- a/components/templates/trending-posts.php
+++ b/components/templates/trending-posts.php
@@ -9,7 +9,7 @@
 			<a href="{{url}}"><i class="goicon icon-chevron-{{trend_direction}}"></i></a>
 		</div>
 		<div class="thumb">
-			<a href="{{url}}"><img src="{{thumbnail}}" width="64" height="64"/></a>
+			<a href="{{url}}"><img src="{{url}}/go-fetch-featured-image/small-square-thumbnail/" width="64" height="64"/></a>
 		</div>
 		<header>
 			<div class="subheader subdued channel">{{sections.primary_channel}}</div>


### PR DESCRIPTION
Tweaking to prepare for more Optimizely tests by adding `.hide-channel` and support for the new thumbnail endpoint.

See: https://github.com/GigaOM/gigaom/issues/6828
